### PR TITLE
Update duckduckgo_search

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-duckduckgo_search==5.2.1
+duckduckgo_search>=7.0.0
 fastcore>=1.5.29
 fastdownload>=0.0.7


### PR DESCRIPTION
Getting 202s w/ earlier versions, fixed [in duckduckgo_search 6.3.0](https://github.com/deedy5/duckduckgo_search/issues/254#issuecomment-2396468832), but works w/ >=7.0.0 too.